### PR TITLE
fix: workflow permissions and use inst/WORDLIST

### DIFF
--- a/.github/linters/.cspell-wordlist.json
+++ b/.github/linters/.cspell-wordlist.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "ignorePaths": [
+    ".github/**",
+    "man/**",
+    "README.md",
+    ".gitignore",
+    ".Rbuildignore",
+    ".cspell.json",
+    ".lintr",
+    "inst/WORDLIST",
+    "docs/**"
+    ],
+  "patterns": [
+    {
+      "name": "code_chunk",
+      "pattern": "`{3}.*?`{3}"
+    }
+  ],
+  "ignoreRegExpList": [
+    "code_chunk"
+  ],
+  "words": [
+    "nolint"
+  ],
+  "dictionaries": [
+    "wordlist"
+  ],
+  "dictionaryDefinitions": [
+    {
+      "name": "wordlist",
+      "path": "inst/WORDLIST"
+    }
+  ]
+}

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -13,7 +13,6 @@ on:
   workflow_call: null
 permissions:
   contents: write
-  issues: write
   pull-requests: write
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -34,9 +34,9 @@ jobs:
           curl --output .mega-linter.yml  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.mega-linter.yml
           curl --output .lintr  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.lintr
           if [ -e "inst/WORDLIST" ]; then
-            curl --output .cspell.json  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell-wordlist.json
-          else 
-            curl --output .cspell.json  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell.json
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/refs/heads/fix/permissions/.github/linters/.cspell-wordlist.json
+          else
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell.json
           fi
       - name: MegaLinter
         id: ml

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -34,7 +34,7 @@ jobs:
           curl --output .mega-linter.yml  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.mega-linter.yml
           curl --output .lintr  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.lintr
           if [ -e "inst/WORDLIST" ]; then
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/refs/heads/fix/permissions/.github/linters/.cspell-wordlist.json
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell-wordlist.json
           else
             curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell.json
           fi

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -33,7 +33,11 @@ jobs:
         run: | 
           curl --output .mega-linter.yml  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.mega-linter.yml
           curl --output .lintr  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.lintr
-          curl --output .cspell.json  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell.json
+          if [ -e "inst/WORDLIST" ]; then
+            curl --output .cspell.json  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell-wordlist.json
+          else 
+            curl --output .cspell.json  https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell.json
+          fi
       - name: MegaLinter
         id: ml
         uses: oxsecurity/megalinter@v7

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It contains the following workflows:
 2. [R-CMD-check NN versions](.github/workflows/check_nn_versions.yaml): Same as 1., but uses the R version and packages available as per given lock dates.
 3. [Test coverage](.github/workflows/coverage.yaml): Derives test coverage for the package and publishes a summary table to the pull request.
 4. [pkgdown](.github/workflows/pkgdown.yaml): Renders and publishes a `pkgdown` website for your package (to your `gh-pages` branch). For a pull request the page is published to `{base url of package}/dev/{pr number}`, and a link to this development webpage is posted as a comment to your pull request.
-5. [megalinter](.github/workflows/megalinter.yaml): Lints your entire project using the [megalinter](https://megalinter.io/) tool.
+5. [megalinter](.github/workflows/megalinter.yaml): Lints your entire project using the [megalinter](https://megalinter.io/) tool. Note that for the [cspell](https://github.com/streetsidesoftware/cspell) linter words in `inst/WORDLIST` are automatically added as a dictionry if the file exists.
 
 ## Use in your package
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ on:
     branches:
       - main
       - master
+permissions:
+  contents: write
+  pull-requests: write
 name: All actions
 jobs:
   check-current-version:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It contains the following workflows:
 2. [R-CMD-check NN versions](.github/workflows/check_nn_versions.yaml): Same as 1., but uses the R version and packages available as per given lock dates.
 3. [Test coverage](.github/workflows/coverage.yaml): Derives test coverage for the package and publishes a summary table to the pull request.
 4. [pkgdown](.github/workflows/pkgdown.yaml): Renders and publishes a `pkgdown` website for your package (to your `gh-pages` branch). For a pull request the page is published to `{base url of package}/dev/{pr number}`, and a link to this development webpage is posted as a comment to your pull request.
-5. [megalinter](.github/workflows/megalinter.yaml): Lints your entire project using the [megalinter](https://megalinter.io/) tool. Note that for the [cspell](https://github.com/streetsidesoftware/cspell) linter words in `inst/WORDLIST` are automatically added as a dictionry if the file exists.
+5. [megalinter](.github/workflows/megalinter.yaml): Lints your entire project using the [megalinter](https://megalinter.io/) tool. Note that for the [cspell](https://github.com/streetsidesoftware/cspell) linter words in `inst/WORDLIST` are automatically added as a dictionary if the file exists.
 
 ## Use in your package
 


### PR DESCRIPTION
Updated the following to make Megalinters `checkov` and `cspell` checks work as intended:

- For `checkov` the individual repos should set the relevant permissions before calling the workflows. This is now reflected in the snippet in the readme.
- Unnecessary permission `issue: write` has been removed from he MegaLinter workflow.
- Added a second `cspell` configuration that adds the `inst/WORDLIST` file used by `pre.commit` to the dictionary of approved words.
- Changed Megalinter workflow to use the above configuration if `inst/WORDLIST` exists, and otherwise use the old one.

Note: It is hard to test the workflows before approving, since they point to a main branch, wherein the files do not exist yet. I have made a previous test run on {whirl} that shows it is working:

https://github.com/NovoNordisk-OpenSource/whirl/actions/runs/12432723171/job/34712764428?pr=126