### PR TITLE
fix: no object_length linter

### DIFF
--- a/.github/linters/.lintr
+++ b/.github/linters/.lintr
@@ -2,6 +2,7 @@ linters: linters_with_defaults(
   line_length_linter(120),
   object_usage_linter = NULL,
   object_name_linter = NULL,
+  object_length_linter = NULL,
   return_linter = NULL
   ) # see vignette("lintr")
 exclusions: list(


### PR DESCRIPTION
Disable object_length linter for lintr since it is not recognizing s3 methods correctly, and thereby throws false errors.