### PR TITLE
fix: regex for cran link

### DIFF
--- a/.github/linters/.lycheeignore
+++ b/.github/linters/.lycheeignore
@@ -1,4 +1,4 @@
 # Dead irrelevant path in pkgdown/favicon
 http://svgjs.dev/svgjs
 # Path to RSPM yet to be derived
-https://packagemanager.posit.co/cran/$%7B%7Bmatrix.config.date 
+https://packagemanager\\.posit\\.co/cran/\\$*

--- a/.github/linters/.lycheeignore
+++ b/.github/linters/.lycheeignore
@@ -1,4 +1,4 @@
 # Dead irrelevant path in pkgdown/favicon
 http://svgjs.dev/svgjs
 # Path to RSPM yet to be derived
-https://packagemanager\\.posit\\.co/cran/\\$.*
+https://packagemanager.posit.co/cran/$%7B%7Bmatrix.config.date 

--- a/.github/linters/.lycheeignore
+++ b/.github/linters/.lycheeignore
@@ -1,4 +1,4 @@
 # Dead irrelevant path in pkgdown/favicon
 http://svgjs.dev/svgjs
 # Path to RSPM yet to be derived
-https://packagemanager\\.posit\\.co/cran/\\$*
+https://packagemanager\\.posit\\.co/cran/\\$.*

--- a/.github/linters/.lycheeignore
+++ b/.github/linters/.lycheeignore
@@ -1,4 +1,6 @@
 # Dead irrelevant path in pkgdown/favicon
 http://svgjs.dev/svgjs
 # Path to RSPM yet to be derived
-https://packagemanager.posit.co/cran/$%7B%7Bmatrix.config.date 
+https://packagemanager.posit.co/cran/\$
+# Paths to workflows yet to be derived
+https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/\$

--- a/.github/linters/.mega-linter.yml
+++ b/.github/linters/.mega-linter.yml
@@ -5,7 +5,7 @@ DISABLE_LINTERS:
 ADDITIONAL_EXCLUDED_DIRECTORIES:
   - dev
 REPOSITORY_KICS_ARGUMENTS: "--exclude-queries 555ab8f9-2001-455e-a077-f2d0f41e2fb9"
-SPELL_LYCHEE_ARGUMENTS: "--exclude-path man/figures --exclude-path docs --exclude-path pkgdown/favicon"
+SPELL_LYCHEE_ARGUMENTS: "--exclude-path man/figures --exclude-path docs --exclude-path pkgdown/favicon --exclude-path .lycheeignore"
 SPELL_LYCHEE_FILE_EXTENSIONS: 
   - "*"
 SPELL_CSPELL_ANALYZE_FILE_NAMES: false

--- a/.github/linters/.mega-linter.yml
+++ b/.github/linters/.mega-linter.yml
@@ -5,7 +5,7 @@ DISABLE_LINTERS:
 ADDITIONAL_EXCLUDED_DIRECTORIES:
   - dev
 REPOSITORY_KICS_ARGUMENTS: "--exclude-queries 555ab8f9-2001-455e-a077-f2d0f41e2fb9"
-SPELL_LYCHEE_ARGUMENTS: "--exclude-path man/figures --exclude-path docs --exclude-path pkgdown/favicon --exclude-path .lycheeignore"
+SPELL_LYCHEE_ARGUMENTS: "--exclude-path man/figures --exclude-path docs --exclude-path pkgdown/favicon --exclude-path .lycheeignore --exclude-path .github/linters/.lycheeignore"
 SPELL_LYCHEE_FILE_EXTENSIONS: 
   - "*"
 SPELL_CSPELL_ANALYZE_FILE_NAMES: false

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: >
           options(
-            repos = c(CRAN = "https://packagemanager.posit.co/cran/${{matrix.config.date }}")
+            repos = c(CRAN = "https://packagemanager.posit.co/cran/${{matrix.config.date}}")
             )
 
           install.packages(c("rcmdcheck", "pak"), Ncpus = parallel::detectCores()-1)

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -32,14 +32,16 @@ jobs:
         shell: bash
         run: | 
           if ["${GITHUB_REPOSITORY,,}" = "novonordisk-opensource/r.workflows"]; then
-            workflow_branch="${GITHUB_REF_NAME}"
-            echo $(workflow_branch)
+            workflow_branch="$GITHUB_REF_NAME"
+            echo --------------------->
+            echo $workflow_branch
+            echo --------------------->
           else
             workflow_branch="main"
           fi
-          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.mega-linter.yml
-          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lintr
-          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lycheeignore
+          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/$workflow_branch/.github/linters/.mega-linter.yml
+          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/$workflow_branch/.github/linters/.lintr
+          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/$workflow_branch/.github/linters/.lycheeignore
           if [ -e "inst/WORDLIST" ]; then
             curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell-wordlist.json
           else

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -33,10 +33,11 @@ jobs:
         run: | 
           echo ===========
           echo $GITHUB_REPOSITORY
+          echo $GITHUB_HEAD_REF
           echo $GITHUB_REF_NAME
           echo ===========
-          if [ "GITHUB_REPOSITORY" = "NovoNordisk-OpenSource/r.workflows" ]; then
-            workflow_branch="$GITHUB_REF_NAME"
+          if [ "$GITHUB_REPOSITORY" = "NovoNordisk-OpenSource/r.workflows" ]; then
+            workflow_branch=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
           else
             workflow_branch="main"
           fi

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Copy linting config from r.workflows/main
         shell: bash
         run: | 
-          if ["${GITHUB_REPOSITORY,,}" = "novonordisk-opensource/r.workflows"]
+          if ["${GITHUB_REPOSITORY,,}" = "novonordisk-opensource/r.workflows"]; then
             workflow_branch="${GITHUB_REF_NAME}"
           else
             workflow_branch="main"

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -33,6 +33,7 @@ jobs:
         run: | 
           if ["${GITHUB_REPOSITORY,,}" = "novonordisk-opensource/r.workflows"]; then
             workflow_branch="${GITHUB_REF_NAME}"
+            echo $(workflow_branch)
           else
             workflow_branch="main"
           fi

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -44,13 +44,13 @@ jobs:
           else
             workflow_branch="main"
           fi
-          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.mega-linter.yml
-          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lintr
-          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lycheeignore
+          curl --output .mega-linter.yml "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.mega-linter.yml"
+          curl --output .lintr "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lintr"
+          curl --output .lycheeignore "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lycheeignore"
           if [ -e "inst/WORDLIST" ]; then
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell-wordlist.json
+            curl --output .cspell.json "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell-wordlist.json"
           else
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell.json
+            curl --output .cspell.json "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell.json"
           fi
       - name: MegaLinter
         id: ml

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -33,7 +33,7 @@ jobs:
         run: | 
           curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.mega-linter.yml
           curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.lintr
-          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.lycheeignore
+          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/fix/lycheignore/.github/linters/.lycheeignore
           if [ -e "inst/WORDLIST" ]; then
             curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell-wordlist.json
           else

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -44,13 +44,13 @@ jobs:
           else
             workflow_branch="main"
           fi
-          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.mega-linter.yml
-          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.lintr
-          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.lycheeignore
+          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.mega-linter.yml
+          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lintr
+          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lycheeignore
           if [ -e "inst/WORDLIST" ]; then
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.cspell-wordlist.json
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell-wordlist.json
           else
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.cspell.json
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell.json
           fi
       - name: MegaLinter
         id: ml

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -31,8 +31,11 @@ jobs:
       - name: Copy linting config from r.workflows/main
         shell: bash
         run: | 
+          echo ===========
+          echo $GITHUB_REPOSITORY
+          echo $GITHUB_REF_NAME
+          echo ===========
           if [ "GITHUB_REPOSITORY" = "NovoNordisk-OpenSource/r.workflows" ]; then
-            echo $GITHUB_REF_NAME
             workflow_branch="$GITHUB_REF_NAME"
           else
             workflow_branch="main"

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -32,25 +32,25 @@ jobs:
         shell: bash
         run: | 
           echo ===========
-          echo ${GITHUB_REPOSITORY}
-          echo ${GITHUB_HEAD_REF}
-          echo ${GITHUB_REF_NAME}
+          echo "${GITHUB_REPOSITORY}"
+          echo "${GITHUB_HEAD_REF}"
+          echo "${GITHUB_REF_NAME}"
           echo ===========
           if [ "$GITHUB_REPOSITORY" = "NovoNordisk-OpenSource/r.workflows" ]; then
-            workflow_branch=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
+            workflow_branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
             echo =========
-            echo Using ${workflow_branch}
+            echo Using "${workflow_branch}"
             echo =========
           else
             workflow_branch="main"
           fi
-          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/$workflow_branch/.github/linters/.mega-linter.yml
-          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/$workflow_branch/.github/linters/.lintr
-          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/$workflow_branch/.github/linters/.lycheeignore
+          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.mega-linter.yml
+          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.lintr
+          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.lycheeignore
           if [ -e "inst/WORDLIST" ]; then
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell-wordlist.json
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.cspell-wordlist.json
           else
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell.json
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/"${workflow_branch}"/.github/linters/.cspell.json
           fi
       - name: MegaLinter
         id: ml

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -32,12 +32,15 @@ jobs:
         shell: bash
         run: | 
           echo ===========
-          echo $GITHUB_REPOSITORY
-          echo $GITHUB_HEAD_REF
-          echo $GITHUB_REF_NAME
+          echo ${GITHUB_REPOSITORY}
+          echo ${GITHUB_HEAD_REF}
+          echo ${GITHUB_REF_NAME}
           echo ===========
           if [ "$GITHUB_REPOSITORY" = "NovoNordisk-OpenSource/r.workflows" ]; then
             workflow_branch=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}
+            echo =========
+            echo Using ${workflow_branch}
+            echo =========
           else
             workflow_branch="main"
           fi

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -31,13 +31,18 @@ jobs:
       - name: Copy linting config from r.workflows/main
         shell: bash
         run: | 
-          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.mega-linter.yml
-          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.lintr
-          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/fix/lycheignore/.github/linters/.lycheeignore
-          if [ -e "inst/WORDLIST" ]; then
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell-wordlist.json
+          if ["${GITHUB_REPOSITORY,,}" = "novonordisk-opensource/r.workflows"]
+            workflow_branch="${GITHUB_REF_NAME}"
           else
-            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/main/.github/linters/.cspell.json
+            workflow_branch="main"
+          fi
+          curl --output .mega-linter.yml https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.mega-linter.yml
+          curl --output .lintr https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lintr
+          curl --output .lycheeignore https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lycheeignore
+          if [ -e "inst/WORDLIST" ]; then
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell-wordlist.json
+          else
+            curl --output .cspell.json https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell.json
           fi
       - name: MegaLinter
         id: ml

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Copy linting config from r.workflows/main
         shell: bash
         run: | 
-          if ["${GITHUB_REPOSITORY,,}" = "novonordisk-opensource/r.workflows"]; then
+          if [ "GITHUB_REPOSITORY" = "NovoNordisk-OpenSource/r.workflows" ]; then
             workflow_branch="$GITHUB_REF_NAME"
             echo --------------------->
             echo $workflow_branch

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -32,9 +32,9 @@ jobs:
         shell: bash
         run: | 
           echo ===========
-          echo "${GITHUB_REPOSITORY}"
-          echo "${GITHUB_HEAD_REF}"
-          echo "${GITHUB_REF_NAME}"
+          echo "$GITHUB_REPOSITORY"
+          echo "$GITHUB_HEAD_REF"
+          echo "$GITHUB_REF_NAME"
           echo ===========
           if [ "$GITHUB_REPOSITORY" = "NovoNordisk-OpenSource/r.workflows" ]; then
             workflow_branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -32,10 +32,8 @@ jobs:
         shell: bash
         run: | 
           if [ "GITHUB_REPOSITORY" = "NovoNordisk-OpenSource/r.workflows" ]; then
+            echo $GITHUB_REF_NAME
             workflow_branch="$GITHUB_REF_NAME"
-            echo --------------------->
-            echo $workflow_branch
-            echo --------------------->
           else
             workflow_branch="main"
           fi

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r.workflows
 Title: R package workflows
-Version: 0.0.1.9001
+Version: 0.0.1.9002
 Authors@R: c(
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut"))


### PR DESCRIPTION
Fixes the following:

1. The lychee linter correctly ignores the URLs that are dependent on system variables, which means they cannot be checked.
2. The megalinter workflow now dynamically downloads the right configuration files to make it easier to check PRs such as this one:
    1. If running in this repo it will fetch all downloads from the branch causing the workflow to start
    1. For all other repos it uses the main branch