### PR TITLE
fix: respect repo linter configurations

### DIFF
--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -45,14 +45,24 @@ jobs:
             workflow_branch="main"
           fi
           if [ ! -e ".mega-linter.yml" ]; then
+            echo "==> Adding .mega-linter.yml"
             curl --output .mega-linter.yml "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.mega-linter.yml"
           fi
-          curl --output .lintr "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lintr"
-          curl --output .lycheeignore "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lycheeignore"
-          if [ -e "inst/WORDLIST" ]; then
-            curl --output .cspell.json "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell-wordlist.json"
-          else
-            curl --output .cspell.json "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell.json"
+          if [ ! -e ".lintr" ]; then
+            echo "==> Adding .lintr"
+            curl --output .lintr "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lintr"
+          fi
+          if [ ! -e ".lycheeignore" ]; then
+            echo "==> Adding .lycheeignore"
+            curl --output .lycheeignore "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lycheeignore"
+          fi
+          if [ ! -e ".cspell.json" ]; then
+            echo "==> Adding .cspell.json"
+            if [ -e "inst/WORDLIST" ]; then
+              curl --output .cspell.json "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell-wordlist.json"
+            else
+              curl --output .cspell.json "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.cspell.json"
+            fi
           fi
       - name: MegaLinter
         id: ml

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -44,7 +44,9 @@ jobs:
           else
             workflow_branch="main"
           fi
-          curl --output .mega-linter.yml "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.mega-linter.yml"
+          if [ ! -e ".mega-linter.yml" ]; then
+            curl --output .mega-linter.yml "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.mega-linter.yml"
+          fi
           curl --output .lintr "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lintr"
           curl --output .lycheeignore "https://raw.githubusercontent.com/NovoNordisk-OpenSource/r.workflows/${workflow_branch}/.github/linters/.lycheeignore"
           if [ -e "inst/WORDLIST" ]; then

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r.workflows
 Title: R package workflows
-Version: 0.0.1.9002
+Version: 0.0.1.9003
 Authors@R: c(
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut"))


### PR DESCRIPTION
Only download general linter specifications if they do not already exist in the repo calling the workflow.