### PR TITLE
Aligned NN checks to use r-lib/actions/setup-r-dependencies@v2 

### DIFF
--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -47,16 +47,11 @@ jobs:
         with:
           r-version: '${{ matrix.config.r }}'
           use-public-rspm: false
+          cran: 'https://packagemanager.posit.co/cran/${{matrix.config.date}}'
       - name: Install curl
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt install libcurl4-openssl-dev
-      - name: Configure package repos
-        run: >
-          options(
-            repos = c(CRAN = "https://packagemanager.posit.co/cran/${{matrix.config.date}}")
-          )
-        shell: 'Rscript {0}'
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: 'any::rcmdcheck'

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -48,10 +48,6 @@ jobs:
           r-version: '${{ matrix.config.r }}'
           use-public-rspm: false
           cran: 'https://packagemanager.posit.co/cran/${{matrix.config.date}}'
-      - name: Install curl
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt install libcurl4-openssl-dev
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: 'any::rcmdcheck'

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Package specific setup
-        if:  ${{ inputs.use_local_setup_action }}
+        if: ${{ inputs.use_local_setup_action }}
         uses: ./.github/actions/setup
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
@@ -51,23 +51,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt install libcurl4-openssl-dev
-      - name: Install dependencies
+      - name: Configure package repos
         run: >
           options(
             repos = c(CRAN = "https://packagemanager.posit.co/cran/${{matrix.config.date}}")
-            )
-
-          install.packages(c("rcmdcheck", "pak"), Ncpus = parallel::detectCores()-1)
-
-          pak::pak_update()
-
-          pak::pak()
+          )
         shell: 'Rscript {0}'
-      - name: Session info
-        run: |
-          sessionInfo()
-          installed.packages()[,c("Package", "Version")]
-        shell: 'Rscript {0}'
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: 'any::rcmdcheck'
+          needs: check
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true


### PR DESCRIPTION
closes #27 
This aligns the setup between the standard jobs and the NN jobs setting lock dates.