### PR TITLE
fix: add error message for empty min_lock_date filter

### DIFF
--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Filter lock dates
         id: filter
         run: |
-          echo "config=$(jq --arg date $MIN_LOCK_DATE --compact-output '[.[] | select(.date >= $date)]' config.json)" >> "$GITHUB_OUTPUT"
+          echo "config=$(jq --arg date "$MIN_LOCK_DATE" --compact-output '[.[] | select(.date >= $date)]' config.json)" >> "$GITHUB_OUTPUT"
       - name: Validate filtered versions
         if: steps.filter.outputs.config == '[]'
         run: |

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Validate filtered versions
         if: steps.filter.outputs.config == '[]'
         run: |
-          echo "::error::No R versions match min_lock_date '${{ env.MIN_LOCK_DATE }}'. Choose a date before the earliest configured version."
+          echo "::error::No R versions match min_lock_date '$MIN_LOCK_DATE'. Choose a date before the earliest configured version."
           exit 1
   R-CMD-check:
     needs: filter-nn-versions

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -62,6 +62,11 @@ jobs:
         id: filter
         run: |
           echo "config=$(jq --arg date $MIN_LOCK_DATE --compact-output '[.[] | select(.date >= $date)]' config.json)" >> "$GITHUB_OUTPUT"
+      - name: Validate filtered versions
+        if: steps.filter.outputs.config == '[]'
+        run: |
+          echo "::error::No R versions match min_lock_date '${{ env.MIN_LOCK_DATE }}'. Choose a date before the earliest configured version."
+          exit 1
   R-CMD-check:
     needs: filter-nn-versions
     runs-on: '${{ matrix.os }}'


### PR DESCRIPTION
## Summary
Fail early with a clear error when `min_lock_date` filters out all R versions.

Closes #44

## Changes Made
- Add validation step for empty filtered config in `check_nn_versions.yaml`.
- Quote `$MIN_LOCK_DATE` to fix shellcheck SC2086.

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge