### PR TITLE
fix: update actions/create-github-app-token from v2 to v3

### DIFF
--- a/.github/workflows/check_current_version.yaml
+++ b/.github/workflows/check_current_version.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Generate custom token
         id: generate-token
         if:  ${{ inputs.generate_token }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Generate custom token
         id: generate-token
         if:  ${{ inputs.generate_token }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Generate custom token
         id: generate-token
         if:  ${{ inputs.generate_token }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Generate custom token
         id: generate-token
         if:  ${{ inputs.generate_token }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
 ```
 
 Where the secrets point to a GitHub App in your organisation that have read access to the relevant
-repositories. Using the `actions/create-github-app-token@v2` action this generates a new token, that
+repositories. Using the `actions/create-github-app-token@v3` action this generates a new token, that
 have the necessary access, to be used in the step setting up the R dependencies.
 
 See also [Authenticating with a GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow#authenticating-with-a-github-app)


### PR DESCRIPTION
## Summary
The pinned SHA for `actions/create-github-app-token@v2` (`fee1f7d63c2ff003460e3d139729b119787bc349`) can no longer be resolved by GitHub's codeload, breaking all downstream CI jobs.

Updates from `@v2` to `@v3` across all reusable workflows. The v3 breaking changes (Node 24 requirement, proxy handling via `NODE_USE_ENV_PROXY`) do not affect GitHub-hosted runners. The `app-id` input is deprecated in v3.1+ in favor of `client-id` but remains functional.

See [v3.0.0 release notes](https://github.com/actions/create-github-app-token/releases/tag/v3.0.0) for the full changelog.

## Changes Made
- Updated `actions/create-github-app-token` from `@v2` to `@v3` in 4 workflow files
- Updated README reference from `@v2` to `@v3`

## Testing
- Downstream repos using `r.workflows@main` will validate once merged

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [ ] The PR is ready for review and merge

Closes #55