### PR TITLE
fix: pass GitHub credentials to check and coverage steps

### DIFF
--- a/.github/workflows/check_current_version.yaml
+++ b/.github/workflows/check_current_version.yaml
@@ -84,6 +84,8 @@ jobs:
           extra-packages: any::rcmdcheck, local::. 
           needs: check
       - uses: r-lib/actions/check-r-package@v2
+        env:
+          GITHUB_PAT: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         with:
           upload-snapshots: true
           error-on: '${{ inputs.error-on || env.ERROR_ON_DEFAULT }}'

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -109,6 +109,8 @@ jobs:
           extra-packages: any::rcmdcheck, local::. 
           needs: check
       - uses: r-lib/actions/check-r-package@v2
+        env:
+          GITHUB_PAT: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         with:
           upload-snapshots: true
           error-on: '${{ inputs.error-on || env.ERROR_ON_DEFAULT }}'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -67,6 +67,8 @@ jobs:
             any::knitr
           needs: coverage
       - name: Test coverage
+        env:
+          GITHUB_PAT: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         run: |
           covr::package_coverage() |>
             covr::to_cobertura(filename = "cobertura.xml")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r.workflows
 Title: R package workflows
-Version: 0.0.1.9006
+Version: 0.0.1.9007
 Authors@R: c(
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut"))


### PR DESCRIPTION
## Summary
Relates to #57.

The reusable workflows previously set `GITHUB_PAT` only on the `r-lib/actions/setup-r-dependencies` step. Steps that actually execute R code (`check-r-package`, the coverage `Rscript` block) ran without authentication, so packages calling the GitHub API at test/vignette time (e.g. `gh::gh()`) hit the 60 req/hr unauthenticated rate limit. This PR passes the same `env` block to those steps so they use the 5000 req/hr authenticated limit.

## Changes Made
- `check_current_version.yaml`: add `GITHUB_PAT` env to the `r-lib/actions/check-r-package@v2` step.
- `check_nn_versions.yaml`: add `GITHUB_PAT` env to the `r-lib/actions/check-r-package@v2` step.
- `coverage.yaml`: add `GITHUB_PAT` env to the `Test coverage` run step.

In all cases the value is `${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}`, matching the existing dependency-setup step.

## Testing


## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge