### PR TITLE
fix: set least-privilege permissions in all workflows

### DIFF
--- a/.github/workflows/check_current_version.yaml
+++ b/.github/workflows/check_current_version.yaml
@@ -34,12 +34,13 @@ on:
       TOKEN_APP_PRIVATE_KEY:
         description: Private Key for the GitHub app used to generate a new token
         required: false
-permissions:
-  contents: read
+permissions: {}
 jobs:
   R-CMD-check:
     runs-on: '${{ matrix.config.os }}'
     name: '${{ matrix.config.os }} (${{ matrix.config.r }})'
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -39,11 +39,11 @@ on:
       TOKEN_APP_PRIVATE_KEY:
         description: Private Key for the GitHub app used to generate a new token
         required: false
-permissions:
-  contents: read
+permissions: {}
 jobs:
   filter-nn-versions:
     runs-on: macos-latest
+    permissions: {}
     outputs:
       config: ${{ steps.filter.outputs.config }}
     env:
@@ -71,6 +71,8 @@ jobs:
     needs: filter-nn-versions
     runs-on: '${{ matrix.os }}'
     name: '${{ matrix.os }} (R ${{ matrix.config.r }}, ${{ matrix.config.date }})'
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,12 +34,13 @@ on:
       TOKEN_APP_PRIVATE_KEY:
         description: Private Key for the GitHub app used to generate a new token
         required: false
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 jobs:
   test-coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Generate custom token

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -11,9 +11,7 @@ on:
       - master
   workflow_dispatch: null
   workflow_call: null
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -21,6 +19,9 @@ jobs:
   megalinter:
     name: MegaLinter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Set up node.js 20
         uses: actions/setup-node@v4
@@ -69,9 +70,6 @@ jobs:
         uses: oxsecurity/megalinter@latest
         env:
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          APPLY_FIXES: all
-          APPLY_FIXES_EVENT: pull_request
-          APPLY_FIXES_MODE: pull_request
           JAVASCRIPT_STANDARD_FILTER_REGEX_EXCLUDE: ${{ vars.JAVASCRIPT_STANDARD_FILTER_REGEX_EXCLUDE }}
       - name: Archive production artifacts
         if: success() || failure()
@@ -81,48 +79,3 @@ jobs:
           path: |
             megalinter-reports
             mega-linter.log
-      - name: Create Pull Request with applied fixes
-        id: cpr
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all'
-          || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE
-          == 'pull_request' && (github.event_name == 'push' ||
-          github.event.pull_request.head.repo.full_name == github.repository) &&
-          !contains(github.event.head_commit.message, 'skip fix')
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.access-token || secrets.ACTION_PAT || secrets.GITHUB_TOKEN}}
-          commit-message: "[MegaLinter] Apply linters automatic fixes"
-          title: "[MegaLinter] Apply linters automatic fixes"
-          labels: bot
-      - name: Create PR output
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all'
-          || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE
-          == 'pull_request' && (github.event_name == 'push' ||
-          github.event.pull_request.head.repo.full_name == github.repository) &&
-          !contains(github.event.head_commit.message, 'skip fix')
-        run: >
-          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
-
-          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-      - name: Prepare commit
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all'
-          || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE
-          == 'commit' && github.ref != 'refs/heads/main' && (github.event_name
-          == 'push' || github.event.pull_request.head.repo.full_name ==
-          github.repository) && !contains(github.event.head_commit.message,
-          'skip fix')
-        run: sudo chown -Rc $UID .git/
-      - name: Commit and push applied linter fixes
-        if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all'
-          || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE
-          == 'commit' && github.ref != 'refs/heads/main' && (github.event_name
-          == 'push' || github.event.pull_request.head.repo.full_name ==
-          github.repository) && !contains(github.event.head_commit.message,
-          'skip fix')
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref
-            }}
-          commit_message: "[MegaLinter] Apply linters fixes"
-          commit_user_name: megalinter-bot
-          commit_user_email: actions-robot@novonordisk.com

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,12 +32,13 @@ on:
       TOKEN_APP_PRIVATE_KEY:
         description: Private Key for the GitHub app used to generate a new token
         required: false
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     concurrency:
       group: 'pkgdown-${{ github.event_name != ''pull_request'' || github.run_id }}'
     steps:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r.workflows
 Title: R package workflows
-Version: 0.0.1.9004
+Version: 0.0.1.9005
 Authors@R: c(
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut"))


### PR DESCRIPTION
## Summary
Apply least-privilege `GITHUB_TOKEN` permissions across all workflows. Top-level defaults to no permissions; each job explicitly opts into only the scopes it needs.

## Changes Made
- `pkgdown.yaml`: top-level `permissions: {}`; job grants `contents: write` (gh-pages deploy + dev push) and `pull-requests: write` (sticky PR comment).
- `check_current_version.yaml`: top-level `permissions: {}`; `R-CMD-check` job grants `contents: read` (checkout).
- `check_nn_versions.yaml`: top-level `permissions: {}`; `filter-nn-versions` job gets no permissions; `R-CMD-check` job grants `contents: read`.
- `coverage.yaml`: top-level `permissions: {}`; job grants `contents: read` + `pull-requests: write` (sticky PR comment).
- `megalinter.yaml`: top-level `permissions: {}`; job grants `contents: read` + `pull-requests: write`. Removed the apply-fixes steps (`peter-evans/create-pull-request` and `stefanzweifel/git-auto-commit-action`) along with the associated `APPLY_FIXES*` env vars — these required `contents: write`, which is no longer granted.

## Testing
- Workflow changes only. Will be exercised by this PR's own CI runs (R-CMD-check, coverage with sticky comment, megalinter, pkgdown build + sticky comment + gh-pages dev push).

## Checklist
- [x] Code changes have been tested
- [ ] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge