### PR TITLE
fix: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/check_current_version.yaml
+++ b/.github/workflows/check_current_version.yaml
@@ -60,11 +60,11 @@ jobs:
       R_KEEP_PKG_SOURCE: true
       ERROR_ON_DEFAULT: '"warning"'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Generate custom token
         id: generate-token
         if:  ${{ inputs.generate_token }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
@@ -72,19 +72,19 @@ jobs:
       - name: Package specific setup
         if:  ${{ inputs.use_local_setup_action }}
         uses: ./.github/actions/setup
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: '${{matrix.config.r}}'
           http-user-agent: '${{matrix.config.http-user-agent}}'
           use-public-rspm: true
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         env:
           GITHUB_PAT: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         with:
           extra-packages: any::rcmdcheck, local::. 
           needs: check
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           upload-snapshots: true
           error-on: '${{ inputs.error-on || env.ERROR_ON_DEFAULT }}'

--- a/.github/workflows/check_nn_versions.yaml
+++ b/.github/workflows/check_nn_versions.yaml
@@ -85,11 +85,11 @@ jobs:
       R_KEEP_PKG_SOURCE: 'yes'
       ERROR_ON_DEFAULT: '"warning"'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Generate custom token
         id: generate-token
         if:  ${{ inputs.generate_token }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
@@ -97,20 +97,20 @@ jobs:
       - name: Package specific setup
         if: ${{ inputs.use_local_setup_action }}
         uses: ./.github/actions/setup
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: '${{ matrix.config.r }}'
           use-public-rspm: false
           cran: 'https://packagemanager.posit.co/cran/${{matrix.config.date}}'
           extra-repositories: 'https://novonordisk-opensource.r-universe.dev'
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         env:
           GITHUB_PAT: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         with:
           extra-packages: any::rcmdcheck, local::. 
           needs: check
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           upload-snapshots: true
           error-on: '${{ inputs.error-on || env.ERROR_ON_DEFAULT }}'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -42,11 +42,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Generate custom token
         id: generate-token
         if:  ${{ inputs.generate_token }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
@@ -54,10 +54,10 @@ jobs:
       - name: Package specific setup
         if:  ${{ inputs.use_local_setup_action }}
         uses: ./.github/actions/setup
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           use-public-rspm: true
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         env:
           GITHUB_PAT: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         with:
@@ -97,7 +97,7 @@ jobs:
             writeLines(con = "coverage.md")
         shell: 'Rscript {0}'
       - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: github.event_name == 'pull_request'
         with:
           recreate: true
@@ -105,7 +105,7 @@ jobs:
           path: coverage.md
       - name: Upload coverage reports to Codecov
         if:  ${{ inputs.use_codecov }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5975040f7f7d40edaff8d784b576fd65ae95c073 # v5.5.5
         with:
           fail_ci_if_error: true
           files: "./cobertura.xml"

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -23,10 +23,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Set up node.js 20
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: "20"
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Copy linting config from r.workflows/main

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -24,11 +24,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Copy linting config from r.workflows/main
         shell: bash
         run: | 
@@ -67,13 +67,13 @@ jobs:
           fi
       - name: MegaLinter
         id: ml
-        uses: oxsecurity/megalinter@latest
+        uses: oxsecurity/megalinter@0e3ce9b9c8c10effb9b269509cc47ca17cae31c7 # v9.5.0
         env:
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           JAVASCRIPT_STANDARD_FILTER_REGEX_EXCLUDE: ${{ vars.JAVASCRIPT_STANDARD_FILTER_REGEX_EXCLUDE }}
       - name: Archive production artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: MegaLinter reports
           path: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -42,11 +42,11 @@ jobs:
     concurrency:
       group: 'pkgdown-${{ github.event_name != ''pull_request'' || github.run_id }}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Generate custom token
         id: generate-token
         if:  ${{ inputs.generate_token }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
@@ -54,11 +54,11 @@ jobs:
       - name: Package specific setup
         if:  ${{ inputs.use_local_setup_action }}
         uses: ./.github/actions/setup
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           use-public-rspm: true
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         env:
           GITHUB_PAT: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
         with:
@@ -69,13 +69,13 @@ jobs:
         shell: 'Rscript {0}'
       - name: "Deploy to GitHub pages \U0001F680"
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
         with:
           clean: false
           branch: gh-pages
           folder: docs
       - name: Add pkgdown PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: github.event_name == 'pull_request'
         with:
           recreate: true
@@ -94,7 +94,7 @@ jobs:
           cp -r ./docs/* /home/runner/work/dev
       - name: Check out gh-pages branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: gh-pages
       - name: Copy and push to gh-pages
@@ -116,6 +116,6 @@ jobs:
           git push
       - name: Restore original checkout for cleanup
         if: always() && inputs.use_local_setup_action
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           clean: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r.workflows
 Title: R package workflows
-Version: 0.0.1.9005
+Version: 0.0.1.9006
 Authors@R: c(
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut"))


### PR DESCRIPTION
## Summary
Pin every external GitHub Action used in the workflows to an immutable commit SHA, with the corresponding `x.y.z` release noted in a trailing comment. This hardens the workflows against tag-rewrite and supply-chain attacks while keeping renovate/dependabot able to track updates by reading the comment.

All actions are pinned to the latest patch release within the major already in use, so behaviour should be unchanged with two exceptions:
- `oxsecurity/megalinter` moves from the floating `latest` tag to `v9.5.0`.
- `marocchino/sticky-pull-request-comment` was previously tracking the `v2` branch (now `v2.9.4`); now SHA-pinned to that release.

The `setup-node` step in the megalinter workflow was a leftover from the upstream installer template (`mega-linter-runner` needs Node); since this workflow uses the Docker-based `oxsecurity/megalinter` action, the host Node is unused. The step has been removed.

## Changes Made
- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- `actions/create-github-app-token@v2` → `actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349` (v2.2.2)
- `actions/upload-artifact@v4` → `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2)
- `codecov/codecov-action@v5` → `codecov/codecov-action@5975040f7f7d40edaff8d784b576fd65ae95c073` (v5.5.5)
- `JamesIves/github-pages-deploy-action@v4.5.0` → `JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e` (v4.5.0)
- `marocchino/sticky-pull-request-comment@v2` → `marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405` (v2.9.4)
- `oxsecurity/megalinter@latest` → `oxsecurity/megalinter@0e3ce9b9c8c10effb9b269509cc47ca17cae31c7` (v9.5.0)
- `r-lib/actions/setup-pandoc@v2` → `r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6` (v2.12.1)
- `r-lib/actions/setup-r@v2` → `r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6` (v2.12.1)
- `r-lib/actions/setup-r-dependencies@v2` → `r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6` (v2.12.1)
- `r-lib/actions/check-r-package@v2` → `r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6` (v2.12.1)
- Removed the unused `actions/setup-node@v4` step from `megalinter.yaml`.

## Testing
- CI on this branch.

## Checklist
- [ ] Code changes have been tested
- [ ] Documentation has been updated, if applicable
- [ ] All automated tests pass
- [ ] Coding style and naming conventions have been followed
- [ ] The PR is ready for review and merge
